### PR TITLE
Update toastMake() method to make it work like native toast

### DIFF
--- a/app/src/main/java/com/sdsmdg/demoexample/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/demoexample/MainActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.Toast;
 
 import com.sdsmdg.tastytoast.TastyToast;
 
@@ -15,37 +16,36 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
-
         setContentView(R.layout.activity_main);
     }
 
     public void showSuccessToast(View view) {
         TastyToast.makeText(getApplicationContext(), "Download Successful !", TastyToast.LENGTH_LONG,
-                TastyToast.SUCCESS);
+                TastyToast.SUCCESS).show();
     }
 
     public void showWarningToast(View view) {
         TastyToast.makeText(getApplicationContext(), "Are you sure ?", TastyToast.LENGTH_LONG,
-                TastyToast.WARNING);
+                TastyToast.WARNING).show();
     }
 
     public void showErrorToast(View view) {
         TastyToast.makeText(getApplicationContext(), "Downloading failed ! Try again later ", TastyToast.LENGTH_LONG,
-                TastyToast.ERROR);
+                TastyToast.ERROR).show();
     }
     public void showInfoToast(View view) {
         TastyToast.makeText(getApplicationContext(), "Searching for username : 'Rahul' ", TastyToast.LENGTH_LONG,
-                TastyToast.INFO);
+                TastyToast.INFO).show();
     }
 
     public void showDefaultToast(View view) {
         TastyToast.makeText(getApplicationContext(), "This is Default Toast", TastyToast.LENGTH_LONG,
-                TastyToast.DEFAULT);
+                TastyToast.DEFAULT).show();
     }
 
 
     public void showConfusingToast(View view) {
         TastyToast.makeText(getApplicationContext(), "I don't Know !", TastyToast.LENGTH_LONG,
-                TastyToast.CONFUSING);
+                TastyToast.CONFUSING).show();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/tastytoast/src/main/java/com/sdsmdg/tastytoast/TastyToast.java
+++ b/tastytoast/src/main/java/com/sdsmdg/tastytoast/TastyToast.java
@@ -34,10 +34,8 @@ public class TastyToast {
     static DefaultToastView defaultToastView;
     static ConfusingToastView confusingToastView;
 
-    public static void makeText(Context context, String msg, int length, int type) {
-
+    public static Toast makeText(Context context, String msg, int length, int type) {
         Toast toast = new Toast(context);
-
 
         switch (type) {
             case 1: {
@@ -141,7 +139,7 @@ public class TastyToast {
             }
         }
         toast.setDuration(length);
-        toast.show();
+        return toast;
     }
 
 }


### PR DESCRIPTION
Made TastyToast's `makeText()` method **work like native android toast's method**. TastyToasts can now be called using:

    TastyToast.makeText(...).show()

or

    Toast toast = TastyToast.makeText(...);
    toast.show();
